### PR TITLE
Echo Mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `HESITATION` mode
 - `OVERTHINK` mode
 - `CONFIDENT` mode
+- `ECHO` mode
 ### Changed
 - Test system modified
 - `README.md` updated

--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ with open("output.txt", "w") as file:
 | `TypeMode.HESITATION` | Emit text with occasional pauses within words to simulate human hesitation |
 | `TypeMode.OVERTHINK` | Emit text while occasionally deleting and retyping a chunk of text to simulate overthinking |
 | `TypeMode.CONFIDENT` | Emit text quickly with brief pauses, adding longer delays after punctuation to simulate confident typing |
+| `TypeMode.ECHO` | Emit text with occasional repetition of characters faintly, like a glitchy terminal echo. |
 
 
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ with open("output.txt", "w") as file:
 | `TypeMode.HESITATION` | Emit text with occasional pauses within words to simulate human hesitation |
 | `TypeMode.OVERTHINK` | Emit text while occasionally deleting and retyping a chunk of text to simulate overthinking |
 | `TypeMode.CONFIDENT` | Emit text quickly with brief pauses, adding longer delays after punctuation to simulate confident typing |
-| `TypeMode.ECHO` | Emit text with occasional repetition of characters faintly, like a glitchy terminal echo. |
+| `TypeMode.ECHO` | Emit text with occasional repetition of characters faintly, like a glitchy terminal echo |
 
 
 

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -180,6 +180,14 @@ def test_confident_mode():
     assert buffer.getvalue() == text + "\n"
 
 
+def test_echo_mode():
+    random.seed(1)
+    buffer = io.StringIO()
+    text = "Hello, world!"
+    type_print(text, file=buffer, delay=0.01, mode=TypeMode.ECHO)
+    assert buffer.getvalue() == "Hello, woorrld!\n"
+
+
 def test_default_stdout_capture(capsys):
     type_print("hello", delay=0)
     captured = capsys.readouterr()

--- a/typio/functions.py
+++ b/typio/functions.py
@@ -425,7 +425,7 @@ class _TypioPrinter:
                     i -= delete_count
                     self._sleep(self._delay * 2)
                 i += 1
-    
+
 
     def _mode_confident(self, text: str) -> None:
         """
@@ -441,6 +441,20 @@ class _TypioPrinter:
                 self._sleep(self._delay * 2)
             else:
                 self._sleep()
+
+
+    def _mode_echo(self, text: str) -> None:
+        """
+        Emit text with occasional repetition of characters faintly, like a glitchy terminal echo.
+
+        :param text: text to emit
+        """
+        for c in text:
+            self._emit(c)
+            self._sleep()
+            if random.random() < 0.1 and c.strip():
+                self._emit(c)
+                self._sleep(self._delay * 0.1)
 
 
 class TypioContext:

--- a/typio/params.py
+++ b/typio/params.py
@@ -36,6 +36,7 @@ class TypeMode(Enum):
     HESITATION = "hesitation"
     OVERTHINK = "overthink"
     CONFIDENT = "confident"
+    ECHO = "echo"
 
 
 EXIT_MESSAGE = "See you. Bye!"


### PR DESCRIPTION
#### Reference Issues/PRs
#60 
#### What does this implement/fix? Explain your changes

#### Any other comments?
@sepandhaghighi I didn't understand why `c.lower()` was used for emitting the echoed character, so I removed it. I also made the echo character begin printing a bit faster.