### PR TITLE
Bug/typioprinter write

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Changed
+- `_TypioPrinter.write` return bug fixed
 - Delay zero value bug fixed
 - Jitter zero value bug fixed
 - Test system modified

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -308,6 +308,15 @@ def test_typestyle_return_value():
     assert func() == 42
 
 
+def test_typestyle_stdout_written_return_value():
+    @typestyle()
+    def func():
+        result = sys.stdout.write("Hello")
+        return result
+
+    assert func() == 5
+
+
 def test_typiocontext_with_typestyle(capsys):
     def custom(ctx, text):
         ctx.emit(text.upper())

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -314,7 +314,7 @@ def test_typestyle_stdout_written_return_value():
         result = sys.stdout.write("Hello")
         return result
 
-    assert func() == 5
+    assert func() == len("Hello")
 
 
 def test_typiocontext_with_typestyle(capsys):

--- a/typio/functions.py
+++ b/typio/functions.py
@@ -78,7 +78,7 @@ class _TypioPrinter:
         self._mode = mode
         self._out = out
 
-    def write(self, text: str) -> None:
+    def write(self, text: str) -> int:
         """
         Write text using the configured typing mode.
 

--- a/typio/functions.py
+++ b/typio/functions.py
@@ -90,6 +90,7 @@ class _TypioPrinter:
         else:
             handler = getattr(self, "_mode_{mode}".format(mode=self._mode.value.replace('-', '_')))
             handler(text)
+        return len(text)
 
     def flush(self) -> None:
         """Flush the underlying output stream."""


### PR DESCRIPTION
#### Reference Issues/PRs
#97 
#### What does this implement/fix? Explain your changes
I just returned the length of `text` in `_TypioPrinter.write` function.
#### Any other comments?

